### PR TITLE
Fix USE_X_FORWARDED_FOR for proxied environments

### DIFF
--- a/rated/settings.py
+++ b/rated/settings.py
@@ -17,3 +17,4 @@ REALM_MAP = getattr(settings, 'RATED_REALM_MAP', {})
 # Redis config parameters
 REDIS = getattr(settings, 'RATED_REDIS', {})
 
+USE_X_FORWARDED_FOR = getattr(settings, 'USE_X_FORWARDED_FOR', False)


### PR DESCRIPTION
The settings for USE_X_FORWARDED_FOR were not being respected because the settings were not being passed through.

It was using the local settings in rated.settings, so USE_X_FORWARDED_FOR was not being populated, so ip address was always being set to REMOTE_ADDR.
